### PR TITLE
Adds documentationUrl parameter to functionality anotation

### DIFF
--- a/src/main/java/org/fenixedu/bennu/spring/portal/PortalHandlerMapping.java
+++ b/src/main/java/org/fenixedu/bennu/spring/portal/PortalHandlerMapping.java
@@ -101,7 +101,7 @@ public class PortalHandlerMapping extends RequestMappingHandlerMapping {
             Functionality functionality =
                     new Functionality(SpringPortalBackend.BACKEND_KEY, "/" + path, path.replace('/', '-'), model.accessGroup()
                             .equals(DELEGATE) ? app.getAccessGroup() : model.accessGroup(), title, model.description().equals(
-                            DELEGATE) ? title : getLocalized(model.description()));
+                            DELEGATE) ? title : getLocalized(model.description()), model.documentationUrl());
             app.addFunctionality(functionality);
             functionalities.put(type, functionality);
         }

--- a/src/main/java/org/fenixedu/bennu/spring/portal/SpringFunctionality.java
+++ b/src/main/java/org/fenixedu/bennu/spring/portal/SpringFunctionality.java
@@ -50,4 +50,5 @@ public @interface SpringFunctionality {
 
     String accessGroup() default PortalHandlerMapping.DELEGATE;
 
+    String documentationUrl() default "";
 }


### PR DESCRIPTION
### Features:
- New anotation parameter for documentation url's.
  - For backwards compability, default value is an empty string.
### Dependencies
- Depends on FenixEdu/bennu#182 
